### PR TITLE
[#7 fix] Image viewer does not work without hammerjs

### DIFF
--- a/src/app/imageviewer/imageviewer.component.html
+++ b/src/app/imageviewer/imageviewer.component.html
@@ -1,5 +1,22 @@
-<canvas #imageContainer [width]="width" [height]="height"
-  (tap)="onTap($event)" (pinchin)="processTouchEvent($event)" (pinchout)="processTouchEvent($event)"
-  (panmove)="processTouchEvent($event)" (panend)="onTouchEnd()" (rotatemove)="processTouchEvent($event)"
-    (rotateend)="onTouchEnd()">
-</canvas>
+<ng-container *ngIf="_isHammerPreset">
+  <canvas
+    (panend)="onTouchEnd()"
+    (panmove)="processTouchEvent($event)"
+    (pinchin)="processTouchEvent($event)"
+    (pinchout)="processTouchEvent($event)"
+    (rotateend)="onTouchEnd()"
+    (rotatemove)="processTouchEvent($event)"
+    (tap)="onTap($event)"
+    [height]="height"
+    [width]="width"
+    #imageContainer
+  ></canvas>
+</ng-container>
+
+<ng-container *ngIf="!_isHammerPreset">
+  <canvas
+    [height]="height"
+    [width]="width"
+    #imageContainer
+  ></canvas>
+</ng-container>

--- a/src/app/imageviewer/imageviewer.component.ts
+++ b/src/app/imageviewer/imageviewer.component.ts
@@ -99,6 +99,9 @@ export class ImageViewerComponent implements AfterViewInit, OnDestroy {
   private _imageResource: ImageResourceLoader;
   private _pdfResource: PdfResourceLoader;
 
+  // Dependencies
+  private _isHammerPreset: boolean;
+
   //#endregion
 
   //#region Lifecycle events
@@ -109,6 +112,7 @@ export class ImageViewerComponent implements AfterViewInit, OnDestroy {
     @Inject(IMAGEVIEWER_CONFIG) private config: ImageViewerConfig
   ) {
     this.config = this.extendsDefaultConfig(config);
+    this._isHammerPreset = typeof window['Hammer'] !== 'undefined';
     this._nextPageButton = new Button(this.config.nextPageButton, this.config.buttonStyle);
     this._beforePageButton = new Button(this.config.beforePageButton, this.config.buttonStyle);
     this._zoomOutButton = new Button(this.config.zoomOutButton, this.config.buttonStyle);


### PR DESCRIPTION
Fox for #7 .
HammerGesturesPlugin throws this error if any *tab* or *pin* related binding is used, while not having HammerJS at the same time. Added condition fixes that.